### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -141,7 +141,7 @@ psutil==6.1.0
 pyarrow==20.0.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
-pyautogen==0.2.32
+ag2==0.2.32
 pybind11==2.13.1
 pycparser==2.22
 pydantic==2.7.4


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
